### PR TITLE
Update GuestOSFeed.xml

### DIFF
--- a/GuestOS/GuestOSFeed.xml
+++ b/GuestOS/GuestOSFeed.xml
@@ -334,7 +334,6 @@
    <description>The November Guest OS has released </description>
    <pubDate>Sat, 19 December 2020 10:00:00 PST (17:00:00 UST)</pubDate>
   </item>
-  </channel>
 
   <item>
   <title>December 2020 Guest OS Release</title>
@@ -342,7 +341,6 @@
    <description>The December Guest OS has released </description>
    <pubDate>Thu, 14 January 2021 10:00:00 PST (17:00:00 UST)</pubDate>
   </item>
-  </channel>
   
   <item>
   <title>January 2020 Guest OS Release</title>
@@ -350,8 +348,6 @@
    <description>The January Guest OS has released </description>
    <pubDate>Fri, 5 February 2021 10:00:00 PST (17:00:00 UST)</pubDate>
   </item>
-  </channel>
-
 
   <item>
   <title>February 2021 Guest OS Release</title>
@@ -359,7 +355,6 @@
    <description>The February Guest OS has released </description>
    <pubDate>Fri, 19 February 2021 10:00:00 PST (17:00:00 UST)</pubDate>
   </item>
-  </channel>
 
   <item>
   <title>March 2021 Guest OS Release</title>


### PR DESCRIPTION
Hi Team, 

The xml format issue cause the recent update cannot publish in the RSS feed and stuck. 

stuck at November 2020 Guest OS Release

Remove the incorrect </channel>. Please review.